### PR TITLE
Trigger checkout popup on proceed

### DIFF
--- a/app/code/Custom/CheckoutPopup/etc/module.xml
+++ b/app/code/Custom/CheckoutPopup/etc/module.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Custom_CheckoutPopup" setup_version="1.0.0">
+        <sequence>
+            <module name="Magento_Checkout"/>
+        </sequence>
+    </module>
+</config>
+

--- a/app/code/Custom/CheckoutPopup/registration.php
+++ b/app/code/Custom/CheckoutPopup/registration.php
@@ -1,0 +1,9 @@
+<?php
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Custom_CheckoutPopup',
+    __DIR__
+);
+

--- a/app/code/Custom/CheckoutPopup/view/frontend/layout/default.xml
+++ b/app/code/Custom/CheckoutPopup/view/frontend/layout/default.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="after.body.start">
+            <block class="Magento\Framework\View\Element\Template" name="custom.checkout.popup.container" template="Custom_CheckoutPopup::container.phtml"/>
+        </referenceContainer>
+    </body>
+    
+</page>
+

--- a/app/code/Custom/CheckoutPopup/view/frontend/requirejs-config.js
+++ b/app/code/Custom/CheckoutPopup/view/frontend/requirejs-config.js
@@ -1,0 +1,13 @@
+var config = {
+    config: {
+        mixins: {
+            'Magento_Checkout/js/proceed-to-checkout': {
+                'Custom_CheckoutPopup/js/proceed-to-checkout-mixin': true
+            },
+            'Mageplaza_SocialLogin/js/proceed-to-checkout': {
+                'Custom_CheckoutPopup/js/proceed-to-checkout-mixin': true
+            }
+        }
+    }
+};
+

--- a/app/code/Custom/CheckoutPopup/view/frontend/templates/container.phtml
+++ b/app/code/Custom/CheckoutPopup/view/frontend/templates/container.phtml
@@ -1,0 +1,2 @@
+<div id="custom-checkout-popup" style="display:none"></div>
+

--- a/app/code/Custom/CheckoutPopup/view/frontend/web/js/proceed-to-checkout-mixin.js
+++ b/app/code/Custom/CheckoutPopup/view/frontend/web/js/proceed-to-checkout-mixin.js
@@ -1,0 +1,65 @@
+define([
+    'jquery',
+    'Magento_Ui/js/modal/modal',
+    'text!Custom_CheckoutPopup/template/popup.html'
+], function ($, modal, popupTpl) {
+    'use strict';
+
+    return function (originalInit) {
+        return function (config, element) {
+            var CLICK_NAMESPACE = '.customCheckoutPopup';
+
+            // Intercept click before original handler is bound
+            $(element).off('click' + CLICK_NAMESPACE).on('click' + CLICK_NAMESPACE, function (event) {
+                var $button = $(this);
+
+                if ($button.data('checkoutPopupConfirmed') === true) {
+                    $button.data('checkoutPopupConfirmed', false);
+                    return; // allow original handler to proceed
+                }
+
+                event.preventDefault();
+                event.stopImmediatePropagation();
+
+                var $container = $('#custom-checkout-popup');
+
+                if ($container.length === 0) {
+                    $container = $('<div id="custom-checkout-popup" style="display:none;"></div>');
+                    $container.html(popupTpl);
+                    $('body').append($container);
+                }
+
+                var modalInstance = modal({
+                    type: 'popup',
+                    title: (config && config.popupTitle) ? config.popupTitle : 'Before you proceed',
+                    modalClass: 'custom-checkout-popup',
+                    responsive: true,
+                    innerScroll: true,
+                    buttons: [
+                        {
+                            text: (config && config.confirmText) ? config.confirmText : 'Continue to checkout',
+                            class: 'action primary',
+                            click: function () {
+                                $button.data('checkoutPopupConfirmed', true);
+                                this.closeModal();
+                                $button.trigger('click');
+                            }
+                        },
+                        {
+                            text: (config && config.cancelText) ? config.cancelText : 'Cancel',
+                            class: 'action secondary',
+                            click: function () {
+                                this.closeModal();
+                            }
+                        }
+                    ]
+                }, $container);
+
+                $container.modal('openModal');
+            });
+
+            return originalInit(config, element);
+        };
+    };
+});
+

--- a/app/code/Custom/CheckoutPopup/view/frontend/web/template/popup.html
+++ b/app/code/Custom/CheckoutPopup/view/frontend/web/template/popup.html
@@ -1,0 +1,4 @@
+<div class="custom-checkout-popup-content">
+    <p>Please review your cart before proceeding to checkout.</p>
+</div>
+


### PR DESCRIPTION
Adds a Magento 2 module that displays a custom popup before allowing users to proceed to checkout.

---
<a href="https://cursor.com/background-agent?bcId=bc-65c3d730-e2c2-43b0-98b2-d82ed9d70473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65c3d730-e2c2-43b0-98b2-d82ed9d70473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

